### PR TITLE
Templatize the Zookeeper docker image setting

### DIFF
--- a/clickhouse/templates/zookeeper.yaml
+++ b/clickhouse/templates/zookeeper.yaml
@@ -30,7 +30,7 @@ spec:
       containers:
       - name: k8szk
         imagePullPolicy: Always
-        image: gcr.io/google_samples/k8szk:v1
+        image: "{{ .Values.zookeeper.repository }}:{{ .Values.zookeeper.tag }}"
         ports:
         - containerPort: 2181
           name: client

--- a/clickhouse/values.yaml
+++ b/clickhouse/values.yaml
@@ -24,6 +24,8 @@ client:
 
 # zookeeper
 zookeeper:
+  repository: gcr.io/google_samples/k8szk:v1
+  tag: v1
   replicaCount: 2
   disk: 256Mi
   resources:


### PR DESCRIPTION
Switch from a hard-coded Docker image in the `zookeeper.yaml` file to getting the image name and version from the `values.yaml` file, following the pattern of the clickhouse Docker image