### PR TITLE
Migrate deployments to apps/v1

### DIFF
--- a/clickhouse/templates/client.yaml
+++ b/clickhouse/templates/client.yaml
@@ -10,7 +10,7 @@ spec:
   selector:
     app: clickhouse-client
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: clickhouse-client

--- a/clickhouse/templates/graphite.yaml
+++ b/clickhouse/templates/graphite.yaml
@@ -1,11 +1,14 @@
 {{ if .Values.graphite.enabled }}
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: graphite
 spec:
   replicas: 1
   serviceName: graphite
+  selector:
+    matchLabels:
+      app: graphite
   template:
     metadata:
       labels:

--- a/clickhouse/templates/statefulset.yaml
+++ b/clickhouse/templates/statefulset.yaml
@@ -1,10 +1,13 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: clickhouse
 spec:
   replicas: {{ .Values.clickhouse.replicaCount }}
   serviceName: clickhouse
+  selector:
+    matchLabels:
+      app: clickhouse
   template:
     metadata:
       labels:

--- a/clickhouse/templates/tabix.yaml
+++ b/clickhouse/templates/tabix.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.tabix.enabled }}
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: tabix

--- a/clickhouse/templates/zookeeper.yaml
+++ b/clickhouse/templates/zookeeper.yaml
@@ -13,13 +13,16 @@ spec:
   selector:
     app: zk
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: zk
 spec:
   serviceName: zk
   replicas: {{ .Values.zookeeper.replicaCount }}
+  selector:
+    matchLabels:
+      app: zk
   template:
     metadata:
       labels:


### PR DESCRIPTION
Prevent errors such as
`
Error: INSTALLATION FAILED: unable to build kubernetes objects from release manifest: [resource mapping not found for name: "clickhouse-client" namespace: "" from "": no matches for kind "Deployment" in version "apps/v1beta1"
`
on newer k8s clusters.